### PR TITLE
[BUGFIX] Display edit icons in frontend

### DIFF
--- a/Classes/FrontendEditPanel.php
+++ b/Classes/FrontendEditPanel.php
@@ -302,7 +302,7 @@ class FrontendEditPanel
         $width = MathUtility::forceIntegerInRange($this->backendUser->getTSConfig()['options.']['feedit.']['popupWidth'] ?? 690, 690, 5000, 690);
         $height = MathUtility::forceIntegerInRange($this->backendUser->getTSConfig()['options.']['feedit.']['popupHeight'] ?? 500, 500, 5000, 500);
         $onclick = 'vHWin=window.open(' . GeneralUtility::quoteJSvalue($url . '&returnUrl=' . rawurlencode(PathUtility::getAbsoluteWebPath(GeneralUtility::getFileAbsFileName('EXT:backend/Resources/Public/Html/Close.html')))) . ',\'FEquickEditWindow\',\'width=' . $width . ',height=' . $height . ',status=0,menubar=0,scrollbars=1,resizable=1\');vHWin.focus();return false;';
-        return '<a href="#" class="typo3-editPanel-btn typo3-editPanel-btn-default frontEndEditIconLinks ' . htmlspecialchars($additionalClasses) . '" onclick="' . htmlspecialchars($onclick) . '" style="display: none;">' . $string . '</a>';
+        return '<a href="#" class="typo3-editPanel-btn typo3-editPanel-btn-default frontEndEditIconLinks ' . htmlspecialchars($additionalClasses) . '" onclick="' . htmlspecialchars($onclick) . '">' . $string . '</a>';
     }
 
     /**

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,8 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'feedit',
+    'Configuration/TypoScript',
+    'Frontend Editing'
+);

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,0 +1,8 @@
+plugin.tx_feedit._CSS_DEFAULT_STYLE (
+    .typo3-editPanel-btn .icon-size-small {
+        display: inline-block;
+        height: 16px;
+        line-height: 16px;
+        width: 16px;
+    }
+)


### PR DESCRIPTION
Do not hide them via inline display none.
Instead provide necessary CSS via static TypoScript.