### PR TITLE
[!!!][FEATURE] Support Content Security Policy

### DIFF
--- a/Classes/FrontendEditPanel.php
+++ b/Classes/FrontendEditPanel.php
@@ -13,7 +13,7 @@ namespace TYPO3\CMS\Feedit;
  *
  * The TYPO3 project - inspiring people to share!
  */
-use TYPO3\CMS\Adminpanel\Service\EditToolbarService;
+
 use TYPO3\CMS\Backend\FrontendBackendUserAuthentication;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -22,6 +22,7 @@ use TYPO3\CMS\Core\Type\Bitmask\JsConfirmation;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
+use TYPO3\CMS\Feedit\Service\EditToolbarService;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
@@ -157,7 +158,7 @@ class FrontendEditPanel
 								' . $formTag . $hiddenFieldString . '
 									<input type="hidden" name="TSFE_EDIT[cmd]" value="" />
 									<input type="hidden" name="TSFE_EDIT[record]" value="' . $currentRecord . '" />
-									<div class="typo3-editPanel" style="display: none;">'
+									<div class="typo3-editPanel">'
                                         . '<div class="typo3-editPanel-btn-group">'
                                         . $panel
                                         . '</div>' .

--- a/Classes/Modules/EditModule.php
+++ b/Classes/Modules/EditModule.php
@@ -21,9 +21,10 @@ use TYPO3\CMS\Adminpanel\ModuleApi\AbstractModule;
 use TYPO3\CMS\Adminpanel\ModuleApi\InitializableInterface;
 use TYPO3\CMS\Adminpanel\ModuleApi\PageSettingsProviderInterface;
 use TYPO3\CMS\Adminpanel\ModuleApi\ResourceProviderInterface;
-use TYPO3\CMS\Adminpanel\Service\EditToolbarService;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Feedit\Service\EditToolbarService;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -32,6 +33,20 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class EditModule extends AbstractModule implements PageSettingsProviderInterface, InitializableInterface, ResourceProviderInterface
 {
+    /**
+     * @var UriBuilder
+     */
+    protected $uriBuilder;
+
+    /**
+     * @param UriBuilder $uriBuilder
+     */
+    public function __construct(UriBuilder $uriBuilder)
+    {
+        parent::__construct();
+        $this->uriBuilder = $uriBuilder;
+    }
+
     /**
      * Creates the content for the "edit" section ("module") of the Admin Panel
      *
@@ -53,9 +68,12 @@ class EditModule extends AbstractModule implements PageSettingsProviderInterface
                 ],
                 'toolbar' => $toolbar,
                 'script' => [
-                    'pageUid' => (int)$this->getTypoScriptFrontendController()->page['uid'],
-                    'pageModule' => $this->getPageModule(),
-                    'backendScript' => BackendUtility::getBackendScript(),
+                    'backendScript' => $this->uriBuilder->buildUriFromRoute(
+                        'web_layout',
+                        [
+                            'id' => (int)$this->getTypoScriptFrontendController()->page['uid'],
+                        ]
+                    ),
                     't3BeSitenameMd5' => md5('Typo3Backend-' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename']),
                 ],
             ]
@@ -113,19 +131,6 @@ class EditModule extends AbstractModule implements PageSettingsProviderInterface
      */
     public function initializeModule(ServerRequestInterface $request): void
     {
-        $typoScriptFrontend = $this->getTypoScriptFrontendController();
-        $typoScriptFrontend->displayEditIcons = $this->configurationService->getConfigurationOption('edit', 'displayIcons');
-        $typoScriptFrontend->displayFieldEditIcons = $this->configurationService->getConfigurationOption('edit', 'displayFieldIcons');
-
-        if ($request->getQueryParams()['ADMCMD_editIcons'] ?? $request->getParsedBody()['ADMCMD_editIcons'] ?? false) {
-            $typoScriptFrontend->displayFieldEditIcons = '1';
-        }
-        if ($typoScriptFrontend->displayEditIcons) {
-            $typoScriptFrontend->set_no_cache('Admin Panel: Display edit icons', true);
-        }
-        if ($typoScriptFrontend->displayFieldEditIcons) {
-            $typoScriptFrontend->set_no_cache('Admin Panel: Display field edit icons', true);
-        }
     }
 
     /**

--- a/Classes/Service/EditToolbarService.php
+++ b/Classes/Service/EditToolbarService.php
@@ -1,0 +1,293 @@
+<?php
+declare(strict_types = 1);
+
+namespace TYPO3\CMS\Feedit\Service;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Backend\FrontendBackendUserAuthentication;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\LanguageAspect;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\FrontendRestrictionContainer;
+use TYPO3\CMS\Core\Imaging\Icon;
+use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * Class for the Edit Toolbar
+ *
+ * @internal
+ */
+class EditToolbarService
+{
+
+    /**
+     * Creates the tool bar links for the "edit" section of the Admin Panel.
+     *
+     * @return string A string containing images wrapped in <a>-tags linking them to proper functions.
+     */
+    public function createToolbar(): string
+    {
+        /** @var LanguageAspect $languageAspect */
+        $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
+        $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+        $tsfe = $this->getTypoScriptFrontendController();
+        //  If mod.newContentElementWizard.override is set, use that extension's create new content wizard instead:
+        $moduleName = BackendUtility::getPagesTSconfig($tsfe->page['uid'])['mod.']['newContentElementWizard.']['override'] ?? 'new_content_element';
+        $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+        $perms = $this->getBackendUser()->calcPerms($tsfe->page);
+        $langAllowed = $this->getBackendUser()->checkLanguageAccess($languageAspect->getId());
+        $id = $tsfe->id;
+        $returnUrl = GeneralUtility::getIndpEnv('REQUEST_URI');
+        $classes = 'typo3-adminPanel-btn typo3-adminPanel-btn-default typo3-adminPanel-btn-openBackend';
+        $output = [];
+        $output[] = '<div class="typo3-adminPanel-form-group">';
+        $output[] = '  <div class="typo3-adminPanel-btn-group" role="group">';
+        $t3BeSitenameMd5 = md5('Typo3Backend-' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename']);
+
+        // History
+        $link = (string)$uriBuilder->buildUriFromRoute(
+            'record_history',
+            [
+                'element' => 'pages:' . $id,
+                'returnUrl' => $returnUrl,
+            ]
+        );
+        $title = $this->getLabel('edit_recordHistory');
+        $output[] = '<a class="' .
+                    $classes .
+                    '" href="#"' .
+                    ' data-backendScript="' . htmlspecialchars($link, ENT_QUOTES | ENT_HTML5) . '"' .
+                    ' data-t3BeSitenameMd5="' . $t3BeSitenameMd5 . '"' .
+                    ' title="' .
+                    $title .
+                    '">';
+        $output[] = '  ' . $iconFactory->getIcon('actions-document-history-open', Icon::SIZE_SMALL)->render();
+        $output[] = '</a>';
+
+        // New Content
+        if ($perms & Permission::CONTENT_EDIT && $langAllowed) {
+            $linkParameters = [
+                'id' => $id,
+                'returnUrl' => $returnUrl,
+            ];
+            if (!empty($languageAspect->getId())) {
+                $linkParameters['sys_language_uid'] = $languageAspect->getId();
+            }
+            $link = (string)$uriBuilder->buildUriFromRoute($moduleName, $linkParameters);
+            $icon = $iconFactory->getIcon('actions-add', Icon::SIZE_SMALL)->render();
+            $title = $this->getLabel('edit_newContentElement');
+            $output[] = '<a class="' .
+                        $classes .
+                        '" href="#"' .
+                        ' data-backendScript="' . htmlspecialchars($link, ENT_QUOTES | ENT_HTML5) . '"' .
+                        ' data-t3BeSitenameMd5="' . $t3BeSitenameMd5 . '"' .
+                        ' title="' .
+                        $title .
+                        '">';
+            $output[] = '  ' . $icon;
+            $output[] = '</a>';
+        }
+
+        // Move Page
+        if ($perms & Permission::PAGE_EDIT) {
+            $link = (string)$uriBuilder->buildUriFromRoute(
+                'move_element',
+                [
+                    'table' => 'pages',
+                    'uid' => $id,
+                    'returnUrl' => $returnUrl,
+                ]
+            );
+            $icon = $iconFactory->getIcon('actions-document-move', Icon::SIZE_SMALL)->render();
+            $title = $this->getLabel('edit_move_page');
+            $output[] = '<a class="' .
+                        $classes .
+                        '" href="#"' .
+                        ' data-backendScript="' . htmlspecialchars($link, ENT_QUOTES | ENT_HTML5) . '"' .
+                        ' data-t3BeSitenameMd5="' . $t3BeSitenameMd5 . '"' .
+                        ' title="' .
+                        $title .
+                        '">';
+            $output[] = '  ' . $icon;
+            $output[] = '</a>';
+        }
+
+        // New Page
+        if ($perms & Permission::PAGE_NEW) {
+            $link = (string)$uriBuilder->buildUriFromRoute(
+                'db_new',
+                [
+                    'id' => $id,
+                    'pagesOnly' => 1,
+                    'returnUrl' => $returnUrl,
+                ]
+            );
+            $icon = $iconFactory->getIcon('actions-page-new', Icon::SIZE_SMALL)->render();
+            $title = $this->getLabel('edit_newPage');
+            $output[] = '<a class="' .
+                        $classes .
+                        '" href="#"' .
+                        ' data-backendScript="' . htmlspecialchars($link, ENT_QUOTES | ENT_HTML5) . '"' .
+                        ' data-t3BeSitenameMd5="' . $t3BeSitenameMd5 . '"' .
+                        ' title="' .
+                        $title .
+                        '">';
+            $output[] = '  ' . $icon;
+            $output[] = '</a>';
+        }
+
+        // Edit Page
+        if ($perms & Permission::PAGE_EDIT) {
+            $link = (string)$uriBuilder->buildUriFromRoute(
+                'record_edit',
+                [
+                    'edit[pages][' . $id . ']' => 'edit',
+                    'noView' => 1,
+                    'returnUrl' => $returnUrl,
+                ]
+            );
+            $icon = $iconFactory->getIcon('actions-page-open', Icon::SIZE_SMALL)->render();
+            $title = $this->getLabel('edit_editPageProperties');
+            $output[] = '<a class="' .
+                        $classes .
+                        '" href="#"' .
+                        ' data-backendScript="' . htmlspecialchars($link, ENT_QUOTES | ENT_HTML5) . '"' .
+                        ' data-t3BeSitenameMd5="' . $t3BeSitenameMd5 . '"' .
+                        ' title="' .
+                        $title .
+                        '">';
+            $output[] = '  ' . $icon;
+            $output[] = '</a>';
+        }
+
+        // Edit Page Overlay
+        if ($perms & Permission::PAGE_EDIT && $languageAspect->getId() > 0 && $langAllowed) {
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable('pages');
+            $queryBuilder->setRestrictions(GeneralUtility::makeInstance(FrontendRestrictionContainer::class));
+            $row = $queryBuilder
+                ->select('uid', 'pid', 't3ver_state')
+                ->from('pages')
+                ->where(
+                    $queryBuilder->expr()->eq(
+                        $GLOBALS['TCA']['pages']['ctrl']['transOrigPointerField'],
+                        $queryBuilder->createNamedParameter($id, \PDO::PARAM_INT)
+                    ),
+                    $queryBuilder->expr()->eq(
+                        $GLOBALS['TCA']['pages']['ctrl']['languageField'],
+                        $queryBuilder->createNamedParameter($languageAspect->getId(), \PDO::PARAM_INT)
+                    )
+                )
+                ->setMaxResults(1)
+                ->execute()
+                ->fetch();
+            $tsfe->sys_page->versionOL('pages', $row);
+            if (is_array($row)) {
+                $link = (string)$uriBuilder->buildUriFromRoute(
+                    'record_edit',
+                    [
+                        'edit[pages][' . $row['uid'] . ']' => 'edit',
+                        'noView' => 1,
+                        'returnUrl' => $returnUrl,
+                    ]
+                );
+                $icon = $iconFactory->getIcon('mimetypes-x-content-page-language-overlay', Icon::SIZE_SMALL)
+                    ->render();
+                $title = $this->getLabel('edit_editPageOverlay');
+                $output[] = '<a class="' .
+                            $classes .
+                            '" href="#"' .
+                            ' data-backendScript="' . htmlspecialchars($link, ENT_QUOTES | ENT_HTML5) . '"' .
+                            ' data-t3BeSitenameMd5="' . $t3BeSitenameMd5 . '"' .
+                            ' title="' .
+                            $title .
+                            '">';
+                $output[] = '  ' . $icon;
+                $output[] = '</a>';
+            }
+        }
+
+        // Open list view
+        if ($this->getBackendUser()->check('modules', 'web_list')) {
+            $link = (string)$uriBuilder->buildUriFromRoute(
+                'web_list',
+                [
+                    'id' => $id,
+                    'returnUrl' => GeneralUtility::getIndpEnv('REQUEST_URI'),
+                ]
+            );
+            $icon = $iconFactory->getIcon('actions-system-list-open', Icon::SIZE_SMALL)->render();
+            $title = $this->getLabel('edit_db_list');
+            $output[] = '<a class="' .
+                        $classes .
+                        '" href="#"' .
+                        ' data-backendScript="' . htmlspecialchars($link, ENT_QUOTES | ENT_HTML5) . '"' .
+                        ' data-t3BeSitenameMd5="' . $t3BeSitenameMd5 . '"' .
+                        ' title="' .
+                        $title .
+                        '">';
+            $output[] = '  ' . $icon;
+            $output[] = '</a>';
+        }
+
+        $output[] = '  </div>';
+        $output[] = '</div>';
+        return implode('', $output);
+    }
+
+    /**
+     * Translate given key
+     *
+     * @param string $key Key for a label in the $LOCAL_LANG array of "sysext/core/Resources/Private/Language/locallang_tsfe.xlf
+     * @return string The value for the $key
+     */
+    protected function getLabel($key): ?string
+    {
+        return htmlspecialchars(
+            $this->getLanguageService()->sL('LLL:EXT:feedit/Resources/Private/Language/locallang_edit.xlf:' . $key),
+            ENT_QUOTES | ENT_HTML5
+        );
+    }
+
+    /**
+     * @return FrontendBackendUserAuthentication
+     */
+    protected function getBackendUser(): FrontendBackendUserAuthentication
+    {
+        return $GLOBALS['BE_USER'];
+    }
+
+    /**
+     * @return LanguageService
+     */
+    protected function getLanguageService(): LanguageService
+    {
+        return $GLOBALS['LANG'];
+    }
+
+    /**
+     * @return TypoScriptFrontendController
+     */
+    protected function getTypoScriptFrontendController(): TypoScriptFrontendController
+    {
+        return $GLOBALS['TSFE'];
+    }
+}

--- a/Classes/Service/EditToolbarService.php
+++ b/Classes/Service/EditToolbarService.php
@@ -56,7 +56,7 @@ class EditToolbarService
         $langAllowed = $this->getBackendUser()->checkLanguageAccess($languageAspect->getId());
         $id = $tsfe->id;
         $returnUrl = GeneralUtility::getIndpEnv('REQUEST_URI');
-        $classes = 'typo3-adminPanel-btn typo3-adminPanel-btn-default typo3-adminPanel-btn-openBackend';
+        $classes = 'typo3-adminPanel-btn typo3-adminPanel-btn-default typo3-feedit-btn-openBackend';
         $output = [];
         $output[] = '<div class="typo3-adminPanel-form-group">';
         $output[] = '  <div class="typo3-adminPanel-btn-group" role="group">';

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -15,7 +15,10 @@ return [
             'after' => [
                 'typo3/cms-adminpanel/initiator',
                 'typo3/cms-frontend/page-resolver',
-            ]
+            ],
+            'before' => [
+                'typo3/cms-frontend/prepare-tsfe-rendering',
+            ],
         ],
     ]
 ];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,11 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  TYPO3\CMS\Feedit\:
+    resource: '../Classes/*'
+
+  TYPO3\CMS\Feedit\Modules\EditModule:
+    public: true

--- a/Resources/Private/Language/locallang_edit.xlf
+++ b/Resources/Private/Language/locallang_edit.xlf
@@ -16,6 +16,36 @@
 			<trans-unit id="openAB">
 				<source>Open TYPO3 Backend</source>
 			</trans-unit>
+			<trans-unit id="edit" resname="edit">
+				<source>Editing</source>
+			</trans-unit>
+			<trans-unit id="edit_editFormsOnPage" resname="edit_editFormsOnPage">
+				<source>Editforms on page</source>
+			</trans-unit>
+			<trans-unit id="edit_editNoPopup" resname="edit_editNoPopup">
+				<source>No popup window</source>
+			</trans-unit>
+			<trans-unit id="edit_recordHistory" resname="edit_recordHistory">
+				<source>View record change history</source>
+			</trans-unit>
+			<trans-unit id="edit_newContentElement" resname="edit_newContentElement">
+				<source>Create new content element</source>
+			</trans-unit>
+			<trans-unit id="edit_move_page" resname="edit_move_page">
+				<source>Move page</source>
+			</trans-unit>
+			<trans-unit id="edit_newPage" resname="edit_newPage">
+				<source>Create new page</source>
+			</trans-unit>
+			<trans-unit id="edit_editPageProperties" resname="edit_editPageProperties">
+				<source>Edit page properties</source>
+			</trans-unit>
+			<trans-unit id="edit_editPageOverlay" resname="edit_editPageOverlay">
+				<source>Edit properties of translated page</source>
+			</trans-unit>
+			<trans-unit id="edit_db_list" resname="edit_db_list">
+				<source>Web&gt;List module</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Templates/Modules/Settings/Edit.html
+++ b/Resources/Private/Templates/Modules/Settings/Edit.html
@@ -9,7 +9,7 @@
     value: display.displayIcons }" debug="false"/>
 <f:format.raw>{toolbar}</f:format.raw>
 <div class="typo3-adminPanel-form-group">
-    <a class="typo3-adminPanel-btn typo3-adminPanel-btn-default typo3-adminPanel-btn-openBackend" href="#" data-pageUid="{script.pageUid}" data-pageModule="{script.pageModule}" data-t3BeSitenameMd5="{script.t3BeSitenameMd5}" data-backendScript="{script.backendScript}">
+    <a class="typo3-adminPanel-btn typo3-adminPanel-btn-default typo3-adminPanel-btn-openBackend" href="#" data-t3BeSitenameMd5="{script.t3BeSitenameMd5}" data-backendScript="{script.backendScript}">
         <f:translate key="LLL:EXT:feedit/Resources/Private/Language/locallang_edit.xlf:openAB"/>
     </a>
 </div>

--- a/Resources/Private/Templates/Modules/Settings/Edit.html
+++ b/Resources/Private/Templates/Modules/Settings/Edit.html
@@ -9,7 +9,7 @@
     value: display.displayIcons }" debug="false"/>
 <f:format.raw>{toolbar}</f:format.raw>
 <div class="typo3-adminPanel-form-group">
-    <a class="typo3-adminPanel-btn typo3-adminPanel-btn-default typo3-adminPanel-btn-openBackend" href="#" data-t3BeSitenameMd5="{script.t3BeSitenameMd5}" data-backendScript="{script.backendScript}">
+    <a class="typo3-adminPanel-btn typo3-adminPanel-btn-default typo3-feedit-btn-openBackend" href="#" data-t3BeSitenameMd5="{script.t3BeSitenameMd5}" data-backendScript="{script.backendScript}">
         <f:translate key="LLL:EXT:feedit/Resources/Private/Language/locallang_edit.xlf:openAB"/>
     </a>
 </div>

--- a/Resources/Public/JavaScript/Modules/Edit.js
+++ b/Resources/Public/JavaScript/Modules/Edit.js
@@ -7,12 +7,12 @@ this.Element && function(ElementPrototype) {
 		}
 }(Element.prototype);
 
-function editModuleOnClickHandler(event) {
+function openBackendHandler(event) {
 	event.preventDefault();
 	var element = event.target;
 
 	if (element.tagName !== 'A') {
-		element = element.closest('A.typo3-adminPanel-btn-openBackend');
+		element = element.closest('a.typo3-feedit-btn-openBackend');
 	}
 
 	var vHWin = window.open(element.getAttribute('data-backendScript'), element.getAttribute('data-t3BeSitenameMd5'));
@@ -20,12 +20,40 @@ function editModuleOnClickHandler(event) {
 	return false;
 }
 
-function initializeEditModule() {
-	var editModuleBtnsOpenBackend = document.querySelectorAll('.typo3-adminPanel-btn-openBackend');
-	for (var i = 0, len = editModuleBtnsOpenBackend.length; i < len; i++ ) {
-		editModuleBtnsOpenBackend[i].addEventListener('click', editModuleOnClickHandler);
+function submitFormHandler(event) {
+	event.preventDefault();
+	var element = event.target;
+
+	if (element.tagName !== 'A') {
+		element = element.closest('a.typo3-feedit-btn-submitForm');
 	}
+
+	var execute = true;
+	var form = document[element.getAttribute('data-feedit-formname')];
+	var confirmText = element.getAttribute('data-feedit-confirm');
+
+	if (confirmText) {
+		execute = confirm(confirmText);
+	}
+
+	if (execute) {
+		form.querySelector('.typo3-feedit-cmd').value = element.getAttribute('data-feedit-cmd');
+		form.submit();
+	}
+
+	return false;
 }
 
+function initializeEditModule() {
+	var editModuleBtnsOpenBackend = document.querySelectorAll('.typo3-feedit-btn-openBackend');
+	for (var i = 0, len = editModuleBtnsOpenBackend.length; i < len; i++ ) {
+		editModuleBtnsOpenBackend[i].addEventListener('click', openBackendHandler);
+	}
+
+	var editModuleBtnsSubmitForm = document.querySelectorAll('.typo3-feedit-btn-submitForm');
+	for (var i = 0, len = editModuleBtnsSubmitForm.length; i < len; i++ ) {
+		editModuleBtnsSubmitForm[i].addEventListener('click', submitFormHandler);
+	}
+}
 
 window.addEventListener('load', initializeEditModule, false);

--- a/Resources/Public/JavaScript/Modules/Edit.js
+++ b/Resources/Public/JavaScript/Modules/Edit.js
@@ -1,23 +1,30 @@
+this.Element && function(ElementPrototype) {
+	ElementPrototype.closest = ElementPrototype.closest ||
+		function(selector) {
+			var el = this;
+			while (el.matches && !el.matches(selector)) el = el.parentNode;
+			return el.matches ? el : null;
+		}
+}(Element.prototype);
+
 function editModuleOnClickHandler(event) {
 	event.preventDefault();
 	var element = event.target;
-	if (parent.opener && parent.opener.top) {
-		parent.opener.top.fsMod.recentIds['web'] = element.getAttribute('data-pageUid');
-		if (parent.opener.top && parent.opener.top.nav_frame && parent.opener.top.nav_frame.refresh_nav) {
-			parent.opener.top.nav_frame.refresh_nav();
-		}
-		parent.opener.top.goToModule(element.getAttribute('data-pageModule'));
-		parent.opener.top.focus();
-	} else {
-		var vHWin = window.open(element.getAttribute('data-backendScript'), element.getAttribute('data-t3BeSitenameMd5'));
-		vHWin.focus();
+
+	if (element.tagName !== 'A') {
+		element = element.closest('A.typo3-adminPanel-btn-openBackend');
 	}
+
+	var vHWin = window.open(element.getAttribute('data-backendScript'), element.getAttribute('data-t3BeSitenameMd5'));
+	vHWin.focus();
 	return false;
 }
 
 function initializeEditModule() {
-	var editModuleBtnOpenBackend = document.querySelector('.typo3-adminPanel-btn-openBackend');
-	editModuleBtnOpenBackend.addEventListener('click', editModuleOnClickHandler);
+	var editModuleBtnsOpenBackend = document.querySelectorAll('.typo3-adminPanel-btn-openBackend');
+	for (var i = 0, len = editModuleBtnsOpenBackend.length; i < len; i++ ) {
+		editModuleBtnsOpenBackend[i].addEventListener('click', editModuleOnClickHandler);
+	}
 }
 
 


### PR DESCRIPTION
Do not use any inline style or javascript anymore.
Instead js logic is moved to js file.
Information are passed via data attributes.

Some options are not respected anymore. That's why this change is
breaking. Those options can be considered as obsolete anyway for current
state of the art.

Those options are:

TSConfig:

* options.feedit.popupWidth
* options.feedit.popupHeight

TypoScript:

* stdWrap.editIcons.styleAttribute

Resolves: #4