### PR TITLE
[!!!][FEATURE] Support Content Security Policy

### DIFF
--- a/Classes/Service/EditToolbarService.php
+++ b/Classes/Service/EditToolbarService.php
@@ -56,7 +56,7 @@ class EditToolbarService
         $langAllowed = $this->getBackendUser()->checkLanguageAccess($languageAspect->getId());
         $id = $tsfe->id;
         $returnUrl = GeneralUtility::getIndpEnv('REQUEST_URI');
-        $classes = 'typo3-adminPanel-btn typo3-adminPanel-btn-default typo3-adminPanel-btn-openBackend';
+        $classes = 'typo3-adminPanel-btn typo3-adminPanel-btn-default typo3-feedit-btn-openBackend';
         $output = [];
         $output[] = '<div class="typo3-adminPanel-form-group">';
         $output[] = '  <div class="typo3-adminPanel-btn-group" role="group">';

--- a/Resources/Private/Templates/Modules/Settings/Edit.html
+++ b/Resources/Private/Templates/Modules/Settings/Edit.html
@@ -9,7 +9,7 @@
     value: display.displayIcons }" debug="false"/>
 <f:format.raw>{toolbar}</f:format.raw>
 <div class="typo3-adminPanel-form-group">
-    <a class="typo3-adminPanel-btn typo3-adminPanel-btn-default typo3-adminPanel-btn-openBackend" href="#" data-t3BeSitenameMd5="{script.t3BeSitenameMd5}" data-backendScript="{script.backendScript}">
+    <a class="typo3-adminPanel-btn typo3-adminPanel-btn-default typo3-feedit-btn-openBackend" href="#" data-t3BeSitenameMd5="{script.t3BeSitenameMd5}" data-backendScript="{script.backendScript}">
         <f:translate key="LLL:EXT:feedit/Resources/Private/Language/locallang_edit.xlf:openAB"/>
     </a>
 </div>

--- a/Resources/Public/JavaScript/Modules/Edit.js
+++ b/Resources/Public/JavaScript/Modules/Edit.js
@@ -7,12 +7,12 @@ this.Element && function(ElementPrototype) {
 		}
 }(Element.prototype);
 
-function editModuleOnClickHandler(event) {
+function openBackendHandler(event) {
 	event.preventDefault();
 	var element = event.target;
 
 	if (element.tagName !== 'A') {
-		element = element.closest('A.typo3-adminPanel-btn-openBackend');
+		element = element.closest('a.typo3-feedit-btn-openBackend');
 	}
 
 	var vHWin = window.open(element.getAttribute('data-backendScript'), element.getAttribute('data-t3BeSitenameMd5'));
@@ -20,12 +20,40 @@ function editModuleOnClickHandler(event) {
 	return false;
 }
 
-function initializeEditModule() {
-	var editModuleBtnsOpenBackend = document.querySelectorAll('.typo3-adminPanel-btn-openBackend');
-	for (var i = 0, len = editModuleBtnsOpenBackend.length; i < len; i++ ) {
-		editModuleBtnsOpenBackend[i].addEventListener('click', editModuleOnClickHandler);
+function submitFormHandler(event) {
+	event.preventDefault();
+	var element = event.target;
+
+	if (element.tagName !== 'A') {
+		element = element.closest('a.typo3-feedit-btn-submitForm');
 	}
+
+	var execute = true;
+	var form = document[element.getAttribute('data-feedit-formname')];
+	var confirmText = element.getAttribute('data-feedit-confirm');
+
+	if (confirmText) {
+		execute = confirm(confirmText);
+	}
+
+	if (execute) {
+		form.querySelector('.typo3-feedit-cmd').value = element.getAttribute('data-feedit-cmd');
+		form.submit();
+	}
+
+	return false;
 }
 
+function initializeEditModule() {
+	var editModuleBtnsOpenBackend = document.querySelectorAll('.typo3-feedit-btn-openBackend');
+	for (var i = 0, len = editModuleBtnsOpenBackend.length; i < len; i++ ) {
+		editModuleBtnsOpenBackend[i].addEventListener('click', openBackendHandler);
+	}
+
+	var editModuleBtnsSubmitForm = document.querySelectorAll('.typo3-feedit-btn-submitForm');
+	for (var i = 0, len = editModuleBtnsSubmitForm.length; i < len; i++ ) {
+		editModuleBtnsSubmitForm[i].addEventListener('click', submitFormHandler);
+	}
+}
 
 window.addEventListener('load', initializeEditModule, false);


### PR DESCRIPTION
Do not use any inline style or javascript anymore.
Instead js logic is moved to js file.
Information are passed via data attributes.

Some options are not respected anymore. That's why this change is
breaking. Those options can be considered as obsolete anyway for current
state of the art.

Those options are:

TSConfig:

* options.feedit.popupWidth
* options.feedit.popupHeight

TypoScript:

* stdWrap.editIcons.styleAttribute

Resolves: #4