### PR TITLE
Fix none working backend

### DIFF
--- a/Resources/Public/JavaScript/Modules/Edit.js
+++ b/Resources/Public/JavaScript/Modules/Edit.js
@@ -15,7 +15,7 @@ function openBackendHandler(event) {
 		element = element.closest('a.typo3-feedit-btn-openBackend');
 	}
 
-	var vHWin = window.open(element.getAttribute('data-backendScript'), element.getAttribute('data-t3BeSitenameMd5'));
+	var vHWin = window.open(element.getAttribute('data-backendScript'), element.getAttribute('data-t3BeSitenameMd5'), 'noopener=yes');
 	vHWin.focus();
 	return false;
 }


### PR DESCRIPTION
When opening backend, e.g. to edit content, it was broken.
This is due to the reason that context is missing.
The TYPO3 backend expects an existing JS context when an opener exists.
Therefore prevent opener in JS context. That way TYPO3 backend will
initialize itself properly.
