### PR TITLE
[TASK] Align with new TYPO3 documentation standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[{*.rst,*.rst.txt}]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 3
+max_line_length = 80
+
+# MD-Files
+[*.md]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+max_line_length = 80

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+/Documentation-GENERATED-temp/

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,0 +1,34 @@
+.. More information about this file:
+   https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html#includes-rst-txt
+
+.. ----------
+.. text roles
+.. ----------
+
+.. role:: aspect(emphasis)
+.. role:: bash(code)
+.. role:: html(code)
+.. role:: js(code)
+.. role:: php(code)
+.. role:: rst(code)
+.. role:: sep(strong)
+.. role:: sql(code)
+
+.. role:: tsconfig(code)
+   :class: typoscript
+
+.. role:: typoscript(code)
+.. role:: xml(code)
+   :class: html
+
+.. role:: yaml(code)
+
+.. default-role:: code
+
+.. ---------
+.. highlight
+.. ---------
+
+.. By default, code blocks use PHP syntax highlighting
+
+.. highlight:: php

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,0 +1,89 @@
+.. include:: /Includes.rst.txt
+
+======================
+Basic Frontend Editing
+======================
+
+:Extension key:
+   feedit
+
+:Package name:
+   friendsoftypo3/feedit
+
+:Version:
+   |release|
+
+:Language:
+   en
+
+:Author:
+   TYPO3 contributors
+
+:License:
+   This document is published under the
+   `Creative Commons BY 4.0 <https://creativecommons.org/licenses/by/4.0/>`__
+   license.
+
+:Rendered:
+   |today|
+
+----
+
+This TYPO3 extension is a simple solution to edit TYPO3 page content elements
+directly in the frontend as a logged-in backend user. It adds edit icons around
+elements for this purpose.
+
+The functionality was part of the TYPO3 Core until TYPO3 v10.0, and moved into
+its own extension, receiving its own public repository.
+
+----
+
+**Table of Contents:**
+
+.. contents::
+   :backlinks: top
+   :depth: 2
+   :local:
+
+Installation
+============
+
+The latest version can be installed via `TER`_ or via composer by running
+
+.. code-block:: bash
+
+   composer require friendsoftypo3/feedit
+
+in a TYPO3 v10 installation.
+
+.. _TER: https://extensions.typo3.org/extension/feedit
+
+Current state
+=============
+
+The extension has been part of TYPO3 Core for a very long time but never
+received much love. It may become more healthy if maintained as third-party
+extension and has been extracted for this reason.
+
+Contribution
+============
+
+Feel free to submit any pull request, or add documentation, tests, as you please.
+We will publish a new version every once in a while, depending on the amount of
+changes and pull requests submitted.
+
+License
+=======
+
+The extension is published under GPL v2+, all included third-party libraries are
+published under their respective licenses.
+
+Authors
+=======
+
+Many contributors have been working on this area while this functionality was
+part of the TYPO3 Core. This package is now maintained by a loose group of TYPO3
+enthusiasts inside the TYPO3 Community. Feel free to contact `Benni Mack`_ for
+any questions regarding `feedit`.
+
+.. _Benni Mack: benni.mack@typo3.org

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -29,9 +29,10 @@ Basic Frontend Editing
 
 ----
 
-This TYPO3 extension is a simple solution to edit TYPO3 page content elements
-directly in the frontend as a logged-in backend user. It adds edit icons around
-elements for this purpose.
+This TYPO3 extension is a simple solution to allow a logged in backend user to
+edit content elements of a TYPO3 page via the frontend. It inserts editing icons
+around elements for this purpose, which redirect the user to the corresponding
+content element form in the backend.
 
 The functionality was part of the TYPO3 Core until TYPO3 v10.0, and moved into
 its own extension, receiving its own public repository.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,0 +1,62 @@
+# More information about this file:
+# https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html#settings-cfg
+
+[general]
+
+project     = Basic Frontend Editing
+version     = main
+release     = main
+copyright   = since 2009 by the TYPO3 contributors
+
+[html_theme_options]
+
+# "Edit on GitHub" button
+github_repository    = FriendsOfTYPO3/feedit
+github_branch        = master
+
+# Footer links
+project_home         = https://extensions.typo3.org/extension/feedit/
+project_contact      = https://typo3.slack.com/archives/C025BQLFA
+project_repository   = https://github.com/FriendsOfTYPO3/feedit
+project_issues       = https://github.com/FriendsOfTYPO3/feedit/issues
+project_discussions  =
+
+use_opensearch       =
+
+[intersphinx_mapping]
+
+# Official TYPO3 manuals
+# h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
+# t3cheatsheets  = https://docs.typo3.org/m/typo3/docs-cheatsheets/main/en-us/
+# t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
+# t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
+# t3docteam      = https://docs.typo3.org/m/typo3/team-t3docteam/main/en-us/
+# t3editors      = https://docs.typo3.org/m/typo3/tutorial-editors/main/en-us/
+# t3extbasebook  = https://docs.typo3.org/m/typo3/book-extbasefluid/main/en-us/
+# t3extexample   = https://docs.typo3.org/m/typo3/guide-example-extension-manual/main/en-us/
+# t3home         = https://docs.typo3.org/
+# t3install      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+# t3l10n         = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+# t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/
+# t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
+# t3tca          = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
+# t3templating   = https://docs.typo3.org/m/typo3/tutorial-templating/main/en-us/
+# t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+# t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/main/en-us/
+# t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/
+# t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
+# t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
+# t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+
+# TYPO3 system extensions
+# ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/main/en-us/
+# ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
+# ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/
+# ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
+# ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
+# ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
+# ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
+# ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
+# ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
+# ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/
+# ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/main/en-us/

--- a/README.md
+++ b/README.md
@@ -1,32 +1,19 @@
-# TYPO3 Extension "feedit" - Basic Frontend Editing
+[![Latest Stable Version](https://poser.pugx.org/friendsoftypo3/feedit/v/stable.svg)](https://extensions.typo3.org/extension/feedit/)
+[![TYPO3](https://img.shields.io/badge/TYPO3-10-orange.svg?style=flat-square)](https://get.typo3.org/version/10)
+[![Total Downloads](https://poser.pugx.org/friendsoftypo3/feedit/d/total.svg)](https://packagist.org/packages/friendsoftypo3/feedit)
+[![Monthly Downloads](https://poser.pugx.org/friendsoftypo3/feedit/d/monthly)](https://packagist.org/packages/friendsoftypo3/feedit)
+
+# TYPO3 extension `feedit`
 
 This TYPO3 extension is a simple solution to edit TYPO3 page content elements
 directly in the frontend as a logged-in backend user. It adds edit icons around
 elements for this purpose.
 
-The functionality was part of the TYPO3 Core until TYPO3 v10.0, and moved into its
-own extension, receiving its own public repository.
+The functionality was part of the TYPO3 Core until TYPO3 v10.0, and moved into
+its own extension, receiving its own public repository.
 
-## Installation
-The latest version can be installed via TER (https://typo3.org) or via composer
-by adding `composer require friendsoftypo3/feedit` in a TYPO3 v10.0+ installation.
-
-## Current state
-The extension has been part of TYPO3 Core for a very long time but never
-received much love. It may become more healthy if maintained as third-party
-extension and has been extracted for this reason.
-
-## Contribution
-Feel free to submit any pull request, or add documentation, tests, as you please.
-We will publish a new version every once in a while, depending on the amount of changes
-and pull requests submitted.
-
-### License
-The extension is published under GPL v2+, all included third-party libraries are
-published under their respective licenses.
-
-### Authors
-Many contributors have been working on this area while this functionality was part of
-the TYPO3 Core. This package is now maintained by a loose group of TYPO3 enthusiasts inside
-the TYPO3 Community. Feel free to contact Benni Mack (benni.mack@typo3.org) for any questions
-regarding `feedit`.
+|                  | URL                                                          |
+|------------------|--------------------------------------------------------------|
+| **Repository:**  | https://github.com/FriendsOfTYPO3/feedit                     |
+| **Read online:** | https://docs.typo3.org/p/friendsoftypo3/feedit/main/en-us/   |
+| **TER:**         | https://extensions.typo3.org/extension/feedit                |

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 
 # TYPO3 extension `feedit`
 
-This TYPO3 extension is a simple solution to edit TYPO3 page content elements
-directly in the frontend as a logged-in backend user. It adds edit icons around
-elements for this purpose.
+This TYPO3 extension is a simple solution to allow a logged in backend user to
+edit content elements of a TYPO3 page via the frontend. It inserts editing icons
+around elements for this purpose, which redirect the user to the corresponding
+content element form in the backend.
 
 The functionality was part of the TYPO3 Core until TYPO3 v10.0, and moved into
 its own extension, receiving its own public repository.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "friendsoftypo3/feedit",
 	"type": "typo3-cms-extension",
-	"description": "Provide functionality for edit toolbars of pages and content",
+	"description": "Edit TYPO3 page content elements directly in the frontend as a logged-in backend user.",
 	"homepage": "https://typo3.org",
 	"license": ["GPL-2.0-or-later"],
 	"authors": [{

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "friendsoftypo3/feedit",
 	"type": "typo3-cms-extension",
-	"description": "Edit TYPO3 page content elements directly in the frontend as a logged-in backend user.",
+	"description": "Edit a TYPO3 page content element in the backend by clicking it in the frontend as a logged-in backend user.",
 	"homepage": "https://typo3.org",
 	"license": ["GPL-2.0-or-later"],
 	"authors": [{

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,12 @@
 	"name": "friendsoftypo3/feedit",
 	"type": "typo3-cms-extension",
 	"description": "Edit a TYPO3 page content element in the backend by clicking it in the frontend as a logged-in backend user.",
-	"homepage": "https://typo3.org",
+	"homepage": "https://extensions.typo3.org/extension/feedit",
+	"support": {
+		"issues": "https://github.com/FriendsOfTYPO3/feedit/issues",
+		"source": "https://github.com/FriendsOfTYPO3/feedit",
+		"docs": "https://docs.typo3.org/p/friendsoftypo3/feedit/main/en-us/"
+	},
 	"license": ["GPL-2.0-or-later"],
 	"authors": [{
 		"name": "TYPO3 Core Team",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,6 +1,6 @@
 <?php
 $EM_CONF[$_EXTKEY] = [
-    'title' => 'Frontend Editing',
+    'title' => 'Basic Frontend Editing',
     'description' => '',
     'category' => 'fe',
     'author' => 'Friends of TYPO3',


### PR DESCRIPTION
Note: The extension title was renamed from "Frontend Editing" to "Basic Frontend Editing" to be different from the [EXT:frontend_editing](https://github.com/FriendsOfTYPO3/frontend_editing) title.

Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/182